### PR TITLE
Add Lootr support for Autumnity hut.

### DIFF
--- a/src/main/java/com/minecraftabnormals/autumnity/common/world/gen/feature/structure/MapleWitchHutPieces.java
+++ b/src/main/java/com/minecraftabnormals/autumnity/common/world/gen/feature/structure/MapleWitchHutPieces.java
@@ -84,10 +84,7 @@ public class MapleWitchHutPieces {
 		protected void handleDataMarker(String function, BlockPos pos, IServerWorld worldIn, Random rand, MutableBoundingBox sbb) {
 			if ("chest".equals(function)) {
 				worldIn.setBlock(pos, Blocks.AIR.defaultBlockState(), 3);
-				TileEntity tileentity = worldIn.getBlockEntity(pos.below());
-				if (tileentity instanceof ChestTileEntity) {
-					((ChestTileEntity) tileentity).setLootTable(AutumnityLootTables.CHESTS_MAPLE_WITCH_HUT, rand.nextLong());
-				}
+				LockableLootTileEntity.setLootTable(worldIn, rand, pos.below(), AutumnityLootTables.CHESTS_MAPLE_WITCH_HUT);
 			} else if ("decor".equals(function)) {
 				if (rand.nextInt(2) == 0) {
 					worldIn.setBlock(pos, Blocks.POTTED_RED_MUSHROOM.defaultBlockState(), 2);


### PR DESCRIPTION
The functionality is identical, as the LockableLootTileEntity's static method checks for a correct instance of that tile entity type.

Additionally, it allows for Lootr support by providing the current world generation context.